### PR TITLE
Add rack secure only plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The plugin folders contains templates that can be ran to *plugin* certain librar
 *   ar_textile         - Full support to textile with ActiveRecord
 *   watchr             - generates watchr test scripts
 *   heroku             - Prepare app for deployment to Heroku
+*   secure_only        - Run app on https via rack-secure\_only
+
 ### Templates
 
 The templates folder contains full project generation templates. These files follow the convention of having *_template* appended to the name. (i.e __sampleblog_template.rb__) Included template are:

--- a/plugins/secure_only_plugin.rb
+++ b/plugins/secure_only_plugin.rb
@@ -1,0 +1,8 @@
+##
+# Secure Only plugin on Padrino
+#
+#
+SECURE_ONLY = "    app.use Rack::SecureOnly, :if => Padrino.env == :production"
+
+require_dependencies 'rack-secure_only', :require => 'rack/secure_only'
+initializer :secure_only, SECURE_ONLY


### PR DESCRIPTION
Hi,

I added a plugin to run an app on https.
It uses rack-secure_only.

The plugin configures the app to run on https only in :production mode.
But this can be easily changed by the user.
