### PR TITLE
Upgrade spec.watchr for RSpec 2 

### DIFF
--- a/files/watchrs/spec.watchr
+++ b/files/watchrs/spec.watchr
@@ -11,7 +11,7 @@
 
 def run(cmd)
   puts(cmd)
-  system("spec #{cmd}")
+  system("rspec #{cmd}")
 end
 
 # --------------------------------------------------


### PR DESCRIPTION
RSpec 2 replaces the `spec` command with `rspec`, and since the Padrino
generators use this version, the watchr script should default to that.
