### PR TITLE
Carrierwave + Datamapper

### DIFF
--- a/plugins/carrierwave_plugin.rb
+++ b/plugins/carrierwave_plugin.rb
@@ -85,5 +85,9 @@ UPLOADER
 create_file destination_root('lib/uploader.rb'), UPLOADER
 generate :model, "upload file:text created_at:datetime"
 prepend_file destination_root('app/models/upload.rb'), "require 'carrierwave/orm/#{fetch_component_choice(:orm)}'\n"
+case fetch_component_choice(:orm)
+when 'datamapper'
+  inject_into_file destination_root('app/models/upload.rb'),", :auto_validation => false\n", :after => "property :file, Text"
+end
 inject_into_file destination_root('app/models/upload.rb'),"   mount_uploader :file, Uploader\n", :before => 'end'
 require_dependencies 'carrierwave'


### PR DESCRIPTION
Ran into an issue with the model generated by the Carrierwave plugin when trying create a padrino admin page - the datamapper validations conflict with the carrierwave uploader. This change turns off validations for the file field so that the uploader can work.

There might be a better way to do this.
