### PR TITLE
will_paginate plugin corrections

### DIFF
--- a/plugins/will_paginate_plugin.rb
+++ b/plugins/will_paginate_plugin.rb
@@ -11,5 +11,12 @@
 orm = (choice = fetch_component_choice(:orm)) =~ /sequel|activerecord|datamapper/ ? choice : ""
 orm = '/data_mapper'   if orm == "datamapper"
 orm = '/active_record' if orm == "activerecord"
-inject_into_file destination_root('app/app.rb'), "  register WillPaginate::Sinatra\n", :after => "Padrino::Application\n"
-inject_into_file destination_root('config/boot.rb'),"  require 'will_paginate#{orm}'\n", :after => "after_load do\n"
+orm = '/sequel'        if orm == "sequel"
+inject_into_file destination_root('app/app.rb'), 
+  "  register WillPaginate::Sinatra\n", 
+  :after => "Padrino::Application\n"
+inject_into_file destination_root('config/boot.rb'),
+  "  require 'will_paginate'\n" +
+  "  require 'will_paginate#{orm}'\n" +
+  "  include WillPaginate::Sinatra::Helpers\n",
+  :after => "after_load do\n"


### PR DESCRIPTION
"padrino g plugin will_paginate" should add some lines to config/boot.rb (here for sequel as orm):

Padrino.after_load.do
  require 'will_paginate'
  require 'will_paginate/sequel'
  include WillPaginate::Sinatra::Helpers
end

but was inserts actually:

Padrino.after_load.do
  require 'will_paginatesequel'
end

So there are two lines missing and in front of sequel there is no slash.

This pull request corrects this bug
