### PR TITLE
again will_paginate plugin corrections (issue #34)

### DIFF
--- a/plugins/will_paginate_plugin.rb
+++ b/plugins/will_paginate_plugin.rb
@@ -12,11 +12,30 @@ orm = (choice = fetch_component_choice(:orm)) =~ /sequel|activerecord|datamapper
 orm = '/data_mapper'   if orm == "datamapper"
 orm = '/active_record' if orm == "activerecord"
 orm = '/sequel'        if orm == "sequel"
-inject_into_file destination_root('app/app.rb'), 
-  "  register WillPaginate::Sinatra\n", 
-  :after => "Padrino::Application\n"
 inject_into_file destination_root('config/boot.rb'),
   "  require 'will_paginate'\n" +
   "  require 'will_paginate#{orm}'\n" +
+  "  require 'will_paginate/view_helpers/sinatra'\n" +
   "  include WillPaginate::Sinatra::Helpers\n",
-  :after => "after_load do\n"
+  :after => "before_load do\n"
+inject_into_file destination_root('app/app.rb'), 
+  "  register WillPaginate::Sinatra\n", 
+  :after => "Padrino::Application\n"
+inject_into_file destination_root('Gemfile'),
+  "gem 'will_paginate', '~>3.0'\n",
+  :after => "Component requirements\n"
+
+say '='*65, :green
+say "The 'will_paginate' plugin has been installed!"
+say "Next, follow these steps:"
+say "Run 'bundle install'"
+say "Start (or restart) the padrino server"
+say '='*65, :green
+=begin
+puts '='*65
+puts "The 'will_paginate' plugin has been installed!"
+puts "Next, follow these steps:"
+puts "Run 'bundle install'"
+puts "Start (or restart) the padrino server"
+puts '='*65
+=end


### PR DESCRIPTION
No one is assigned
Sometimes I run into the situation, that my corrections for issue #33 generate at padrino start the error: "uninitialized constant WillPaginate::Sinatra".

I could not pin down the cause for this behavior, but some experiments (with the help of an old will_paginate issue mislav/will_paginate#149) delivered a solution:

I had to move the three will_paginate requires in boot.rb into the Padrion.before_load block.

I will submit an pull request with this change, plus the missing addition to the Gemfile:
inject_into_file destination_root('Gemfile'),
"gem 'will_paginate', '~>3.0'\n",
:after => "Component requirements\n"

best regards
Wolfkibe
