### PR TITLE
Avoid using the protection to a route of better_errors, fixes #62.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To run a plugin:
 - ar\_translate       - Translate for you your ActiveRecord columns.
 - auto\_locale        - Switch for you automatically the I18n.locale.
 - barista            - Add support for Coffeescript via Barista.
-- better\_error       - Add support for the `better_error` Gem.
+- better\_errors       - Add support for the `better_errors` Gem.
 - blueprint          - Blueprint CSS.
 - bootstrap          - Add Twitter bootstrap CSS.
 - bug                - rack-bug plugin.

--- a/plugins/better_errors_plugin.rb
+++ b/plugins/better_errors_plugin.rb
@@ -27,3 +27,4 @@ end
 CONFIG
 
 inject_into_file destination_root('config/boot.rb'), CONFIG, :after => "Bundler.require(:default, PADRINO_ENV)\n"
+inject_into_file destination_root('app/app.rb'), "    set :protect_from_csrf, except: %r{/__better_errors/\d+/\w+\z}", :after => "Padrino::Application\n"


### PR DESCRIPTION
This recipe will inject `set :protect_from_csrf` into `app/app.rb` after `Padrino::Application`.
So, `app/app.rb` will be something like this.

``` ruby
module Foobar
  class App < Padrino::Application
    set :protect_from_csrf, except: %r{/__better_errors/\d+/\w+\z}
    register Padrino::Rendering
    register Padrino::Mailer
    ...
  end
end
```
