### PR TITLE
Raphy Charts (RaphaelJS based charts) plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ To run a plugin:
 - openid             - OpenID authentication via rack-openid.
 - payment            - Payment Plugin via rack-payment.
 - protection         - Add support rack-protection to your app to protect against certain security exploitations.
+- raphy_charts       - Raphy Charts - A RaphaelJS based HTML5/SVG charts library.
 - recaptcha          - CAPTCHA verification using RECAPTCHA API via rack-recaptcha.
 - resque             - Add support for the resque redis based background worker.
 - rewrite            - Rewrite Rules via rack-rewrite.

--- a/plugins/raphy_charts_plugin.rb
+++ b/plugins/raphy_charts_plugin.rb
@@ -1,0 +1,7 @@
+##
+# Plugin for installing Raphy Charts (RaphaelJS based HTML5/SVG charts) into a Padrino project.
+# Must also install the RaphaelJS library and include both into your project views.
+#
+# Javascript files.
+get 'https://raw.github.com/jcarver989/raphy-charts/master/compiled/charts.js', destination_root('public/javascripts/raphy-charts.js')
+get 'https://raw.github.com/jcarver989/raphy-charts/master/compiled/charts.min.js', destination_root('public/javascripts/raphy-charts.min.js')


### PR DESCRIPTION
Plugin to include Raphy Charts (RaphaelJS based HTML5/SVG charts) javascript libraries into any padrino project.