### PR TITLE
Update better_errors_plugin.rb

### DIFF
--- a/plugins/better_errors_plugin.rb
+++ b/plugins/better_errors_plugin.rb
@@ -28,7 +28,7 @@ CONFIG
 
 SETTING = <<-SETTING
   # Use better_errors
-  set :protect_from_csrf, except: %r{/__better_errors/\\d+/\\w+\\z} if Padrino.env == :development
+  set :protect_from_csrf, except: %r{/__better_errors/\\w+/\\w+\\z} if Padrino.env == :development
 SETTING
 
 inject_into_file destination_root('config/boot.rb'), CONFIG,  :before => "Padrino.load!"


### PR DESCRIPTION
The URL schema für better_errors is not limited to digits. There are hexadecimal values that require a word character match.

(It appears like my previous pull request was gone. If you find it then please ignore this duplicate.)
