### PR TITLE
fakeweb support deprecated by vcr in favor of webmock

### DIFF
--- a/plugins/vcr_plugin.rb
+++ b/plugins/vcr_plugin.rb
@@ -1,6 +1,6 @@
 # VCR Plugin
 #
-# Adds VCR to your test config using fakeweb.
+# Adds VCR to your test config using webmock.
 #
 VCR = <<-CONF
 


### PR DESCRIPTION
Looks like fakeweb has been dormant for a while.  vcr has deprecated it (per vcr/vcr#238), so we should update this template.
