### PR TITLE
Updated camorra plugin info in order to show Foundation plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run a plugin:
 - blueprint          - Blueprint CSS.
 - bootstrap          - Add Twitter bootstrap CSS.
 - bug                - rack-bug plugin.
-- camorra            - Add ZURB Foundation CSS
+- camorra            - Add ZURB Foundation CSS.
 - carrierwave        - Carrierwave plugin via carrierwave.
 - codehighlighter    - Code Highlighting via rack-codehighlighter.
 - coderay            - Code Highlighting via rack-coderay.

--- a/plugins/camorra_plugin.rb
+++ b/plugins/camorra_plugin.rb
@@ -1,6 +1,7 @@
-# Add some style to Padrino. Plugin to install ZURB Foundation on Padrino
+# Add some style to Padrino. Plugin to install ZURB Foundation (v5.1.0.0) on Padrino
 #
 # Created by Felipe Cabargas <felipe@cabargas.com>
+# Master Plugin repository: github.com/felipecabargas/camorra
 # Copyleft please!
 #
 # SCSS


### PR DESCRIPTION
As requested by the community, I updated the README of my plugin repo & the info inside the plugin ruby file in this repository in order to show clearly the ZURB Foundation version that is actually being used.
