### PR TITLE
Use the 'order' method instead of the parameter.

### DIFF
--- a/templates/sampleblog_template.rb
+++ b/templates/sampleblog_template.rb
@@ -28,7 +28,7 @@ rake 'ar:migrate'
 generate :controller, "posts get:index get:show"
 gsub_file('app/controllers/posts.rb', /^\s+\#\s+.*\n/,'')
 POST_INDEX_ROUTE = <<-POST
-      @posts = Post.all(:order => 'created_at desc')
+      @posts = Post.all.order('created_at desc')
       render 'posts/index'
 POST
 POST_SHOW_ROUTE = <<-POST


### PR DESCRIPTION
"Post.all(:order => 'created_at desc')" raises an ArgumentError. 
It is better to use the 'order' method instead of the parameter for recent ActiveRecord.
(fix #82)