### PR TITLE
lib/factory_girl.rb -> lib/factory-girl.rb

### DIFF
--- a/plugins/factory_girl_plugin.rb
+++ b/plugins/factory_girl_plugin.rb
@@ -15,7 +15,7 @@ rescue LoadError
 end
 LIB
 
-create_file 'lib/factory-girl.rb', LIB
+create_file 'lib/plugins/factory-girl.rb', LIB
 
 GEMFILE = <<-GEMFILE
 group :development, :test do

--- a/plugins/factory_girl_plugin.rb
+++ b/plugins/factory_girl_plugin.rb
@@ -15,7 +15,7 @@ rescue LoadError
 end
 LIB
 
-create_file 'lib/factory_girl.rb', LIB
+create_file 'lib/factory-girl.rb', LIB
 
 GEMFILE = <<-GEMFILE
 group :development, :test do


### PR DESCRIPTION
Due to LOAD_PATH somehow including "." the plugin required itself
effectively overriding the proper factory_girl. Sigh.