### PR TITLE
add react-sinatra recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ $ padrino-gen plugin <name-of-the-plugin>
 - vcr: Add [vcr](https://github.com/vcr/vcr) to your test suite.
 - watchr: Generates [watchr](https://github.com/mynyml/watchr) test scripts.
 - will\_paginate: Add support for [will_paginate](https://github.com/mislav/will_paginate).
+- react-sinatra: Add support for [react-sinatra](https://github.com/namusyaka/react-sinatra).
 
 
 If you want to contribute with a plugin please follow the convention of having `_plugin` appended to the name (i.e.

--- a/plugins/react-sinatra_plugin.rb
+++ b/plugins/react-sinatra_plugin.rb
@@ -1,0 +1,25 @@
+## 
+# React Ingegration for Padrino
+# @see https://github.com/namusyaka/react-sinatra
+# 
+REACT_SINATRA_INIT = <<-REACT
+  configure do
+    React::Sinatra.configure do |config|
+      config.use_bundled_react = true
+      config.env          =  ENV['RACK_ENV'] || ENV['PADRINO_ENV']
+      config.runtime      = :execjs
+      # Your javascript for server site should be placed in {Padrino.root}client/dist/server.js
+      config.asset_path   = %w(client/dist/server.js)
+      config.pool_size    = 5
+      config.pool_timeout = 10
+    end
+  
+    React::Sinatra::Pool.pool.reset
+  end
+REACT
+
+require_dependencies 'react-sinatra'
+require_dependencies 'execjs'
+require_dependencies 'mini_racer'
+
+inject_into_file destination_root('app/app.rb'), REACT_SINATRA_INIT, :after => "enable :sessions\n"


### PR DESCRIPTION
Hey everyone!

I just released [react-sinatra gem](https://github.com/namusyaka/react-sinatra) to use reactjs with sinatra or padrino.
It draws elements using padrino-helpers by default.
It also supports server-side rendering like react-rails and react_on_rails.

So, I would like to add this gem recipe to padrino.

If you do not mind, please check it.
Thanks!