### PR TITLE
Update better_errors_plugin.rb for latest padrino

### DIFF
--- a/plugins/better_errors_plugin.rb
+++ b/plugins/better_errors_plugin.rb
@@ -28,7 +28,7 @@ CONFIG
 
 SETTING = <<-SETTING
   # Use better_errors
-  set :protect_from_csrf, except: %r{/__better_errors/\\w+/\\w+\\z} if Padrino.env == :development
+  set :protect_from_csrf, except: %r{/__better_errors/\\w+/\\w+\\z} if RACK_ENV == :development
 SETTING
 
 inject_into_file destination_root('config/boot.rb'), CONFIG,  :before => "Padrino.load!"


### PR DESCRIPTION
Padrino.env no longer exists and has been replaced with RACK_ENV. 

Minor tweak but took me a while to figure out why my local system kept thinking it was defending itself from attack via Authenticity token.  =]